### PR TITLE
Added pickling sanity validation for RuntimeTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ docs/_build/
 # PyBuilder
 target/
 /.python-version
+venv
+
+# IDE
+.vscode
+.idea


### PR DESCRIPTION
When you use the uwsgi tasks library without uwsgi running (i.e local development), you will run the tasks immediately with RuntimeTask, which is great.
However, there is one downside - the actual async tasks are pickling the task args and kwargs, while the runtime doesn't, resulting in potential pickling bugs (i.e lambdas are not pickle-able).
This PR is intended to add a small sanity check to the RuntimeTask which will mimic the pickling done by the other tasks to reveal such errors as soon as possible.